### PR TITLE
Make the wrapper work in Rails3

### DIFF
--- a/lib/tainted_hash/rails.rb
+++ b/lib/tainted_hash/rails.rb
@@ -4,7 +4,7 @@ TaintedHash.send :include, TaintedHash::RailsMethods
 
 module TaintedHash::Controller
   def wrap_params_with_tainted_hash
-    @_params = TaintedHash.new(@_params.to_hash)
+    @_params = TaintedHash.new(params.to_hash)
   end
 end
 

--- a/lib/tainted_hash/rails.rb
+++ b/lib/tainted_hash/rails.rb
@@ -4,7 +4,7 @@ TaintedHash.send :include, TaintedHash::RailsMethods
 
 module TaintedHash::Controller
   def wrap_params_with_tainted_hash
-    @_params = TaintedHash.new(params.to_hash)
+    self.params = TaintedHash.new(params.to_hash)
   end
 end
 


### PR DESCRIPTION
In Rails3, @_params is only set when params is called so it is nil by default. Using the params method returns something like a hash so there isn't an error. I don't know for sure but I think this will work in Rails2 as well. 
