### PR TITLE
#to_s should give back the inspection view

### DIFF
--- a/lib/tainted_hash.rb
+++ b/lib/tainted_hash.rb
@@ -197,6 +197,10 @@ class TaintedHash < Hash
     hash
   end
 
+  def to_s
+    self.inspect
+  end
+
   def with_indifferent_access
     self
   end

--- a/test/tainted_hash_test.rb
+++ b/test/tainted_hash_test.rb
@@ -188,4 +188,8 @@ class TaintedHashTest < Test::Unit::TestCase
     slice = @tainted.slice :a, :d
     assert_equal({'a' => 1}, slice.to_hash)
   end
+
+  def test_string_representation_shows_internals
+    assert_match /\A#<TaintedHash:.*>\z/, @tainted.to_s
+  end
 end


### PR DESCRIPTION
I was doing some debugging, and ran across something confusing:

``` ruby
puts params # {}
puts params[:name] # "Aidan"
# wtf??
```

After some banging of my head against the wall, I discovered that `params` was a `TaintedHash`, and that I had merely run myself in circles.  Hopefully this will spare others the same pain in the future.

``` ruby
puts params # #<TaintedHash:2185660760 @hash={"a"=>1, "b"=>2, "c"=>{"name"=>"bob"}} @exposed=[]>
```
