### PR TITLE
Pass to_query arguments to @original_hash

### DIFF
--- a/lib/tainted_hash.rb
+++ b/lib/tainted_hash.rb
@@ -283,8 +283,8 @@ private
       self
     end
 
-    def to_query
-      @original_hash.to_query
+    def to_query(*args)
+      @original_hash.to_query(*args)
     end
   end
 end


### PR DESCRIPTION
`Hash#to_param` (aliased to `to_query`) [takes an optional argument in Rails 3](https://github.com/github/rails/blob/3-0-github/activesupport/lib/active_support/core_ext/object/to_param.rb#L45).

This pull request changes `TaintedHash::RailsMethods#to_query` so that it passes any arguments on.

cc @github/rails 
