### PR TITLE
Define nested_under_indifferent_access to return self

### DIFF
--- a/lib/tainted_hash.rb
+++ b/lib/tainted_hash.rb
@@ -221,6 +221,10 @@ class TaintedHash < Hash
     self
   end
 
+  def nested_under_indifferent_access
+    self
+  end
+
   def inspect
     %(#<#{self.class}:#{object_id} @hash=#{@original_hash.inspect} @exposed=#{keys.inspect}>)
   end


### PR DESCRIPTION
This is required to make `TaintedHash` play nicely with `ActiveSupport::HashWithIndifferentAccess` on Rails 3.2, which calls `nested_under_indifferent_access` rather than `with_indifferent_access` on Hash subclasses.

cc @technoweenie @github/rails3
