### PR TITLE
Define #symbolize_keys for Rails 3.2

### DIFF
--- a/lib/tainted_hash.rb
+++ b/lib/tainted_hash.rb
@@ -260,6 +260,10 @@ private
     hash
   end
 
+  def symbolize_keys
+    to_hash.symbolize_keys
+  end
+
   module RailsMethods
     def self.included(base)
       base.send :alias_method, :stringify_keys!, :stringify_keys

--- a/lib/tainted_hash.rb
+++ b/lib/tainted_hash.rb
@@ -264,6 +264,8 @@ private
     to_hash.symbolize_keys
   end
 
+  undef symbolize_keys!
+
   module RailsMethods
     def self.included(base)
       base.send :alias_method, :stringify_keys!, :stringify_keys


### PR DESCRIPTION
Rails 3.2 calls symbolize_keys on hashes passed in to url_for. Since we pass (sanitized) TaintedHash instances into url_for in a variety of places, we need to make sure we behave as we should when this method is called.

This mirrors the behaviour of AS::HWIA#symbolize_keys.

cc @technoweenie @github/rails3
