### PR TITLE
This fixes warnings on Ruby 2.7

### DIFF
--- a/lib/tainted_hash.rb
+++ b/lib/tainted_hash.rb
@@ -197,9 +197,8 @@ class TaintedHash < Hash
   # Yields the String key, and the value.
   #
   # Returns nothing.
-  def each
+  def each(&block)
     self.class.trigger_no_expose(self) { @exposed_nothing && size.zero? }
-    block = block_given? ? Proc.new : nil
     super(&block)
   end
 


### PR DESCRIPTION
Ruby 2.7 issues warnings for `Proc.new` without a block:

```
warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

This patch converts the `Proc.new` calls in to `&block`